### PR TITLE
Specify GCP policy member type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ invoked periodically via [Cloud Scheduler][cloud-scheduler].
 
     ```sh
     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-      --member "gcr-cleaner@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --member "serviceAccount:gcr-cleaner@${PROJECT_ID}.iam.gserviceaccount.com" \
       --role "roles/browser"
     ```
 


### PR DESCRIPTION
Small documentation fix to specify GCP policy member type as required by `gcloud`.
This is already done here: https://github.com/GoogleCloudPlatform/gcr-cleaner/blob/main/README.md?plain=1#L110
