### PR TITLE
Upgrade tag filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GCR Cleaner
 
-GCR Cleaner deletes untagged images in Google Cloud [Container
+GCR Cleaner deletes stale images in Google Cloud [Container
 Registry][container-registry] or Google Cloud [Artifact
 Registry][artifact-registry]. This can help reduce costs and keep your container
 images list in order.
@@ -169,16 +169,19 @@ The payload is expected to be JSON with the following fields:
   the duration will not be deleted. If unspecified, the default is no grace
   period (all untagged image refs are deleted).
 
-- `allow_tagged` - If set to true, will check all images including tagged.
-  If unspecified, the default will only delete untagged images.
-
 - `keep` - If an integer is provided, it will always keep that minimum number
   of images. Note that it will not consider images inside the `grace` duration.
 
-- `tag_filter` - Used for tags regexp definition to define pattern to clean,
-  requires `allow_tagged` must be true. For example: use `-tag-filter "^dev.+$"`
-  to limit cleaning only on the tags with beginning with is `dev`. The default
-  is no filtering. The regular expression is parsed according to the [Go regexp package syntax](https://golang.org/pkg/regexp/syntax/).
+- `tag_filter_any` - If specified, any image with at **least one tag** that
+  matches this given regular expression will be deleted. The image will be
+  deleted even if it has other tags that do not match the given regular
+  expression. The regular expressions are parsed according to the [Go regexp
+  package][go-re].
+
+- `tag_filter_all` - If specified, any image where **all tags** match this given
+  regular expression will be deleted. The image will not be delete if it has
+  other tags that do not match the given regular expression. The regular
+  expressions are parsed according to the [Go regexp package][go-re].
 
 - `dry_run` - If set to true, will not delete anything and outputs what would
   have been deleted.
@@ -193,6 +196,19 @@ The payload is expected to be JSON with the following fields:
     be very slow! This is because the Docker v2 API does not support server-side
     filtering, meaning GCR Cleaner must download a manifest of all repositories
     to which you have access and then do client-side filtering.
+
+- `tag_filter` (_Deprecated_) - This option is deprecated and only exists to
+  maintain backwards compatibility with some existing broken behavior. You
+  should not use it. If specified, any image where **the first tag** matches
+  this given regular expression will be deleted. The image will not be deleted
+  if other tags match the regular expression. The regular expressions are parsed
+  according to the [Go regexp package][go-re].
+
+- `allow_tagged` (_Deprecated_) - This option is deprecated and has no effect.
+  By default, GCR Cleaner will not delete tagged images. To delete tagged
+  images, specify `tag_filter_any` or `tag_filter_all`. Specifying either of
+  these will enable deletion by tag.
+
 
 ## Running locally
 
@@ -246,3 +262,4 @@ This library is licensed under Apache 2.0. Full license text is available in
 [container-registry]: https://cloud.google.com/container-registry
 [gcr-cleaner-godoc]: https://godoc.org/github.com/sethvargo/gcr-cleaner/pkg/gcrcleaner
 [gcrgc.sh]: https://gist.github.com/ahmetb/7ce6d741bd5baa194a3fac6b1fec8bb7
+[go-re]: https://golang.org/pkg/regexp/syntax/

--- a/pkg/gcrcleaner/filter.go
+++ b/pkg/gcrcleaner/filter.go
@@ -1,0 +1,125 @@
+// Copyright 2021 The GCR Cleaner Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrcleaner
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// TagFilter is an interface which defines whether a given set of tags matches
+// the filter.
+type TagFilter interface {
+	Matches(tags []string) bool
+}
+
+// BuildTagFilter builds and compiles a new tag filter for the given inputs. All
+// inputs are strings to be compiled to regular expressions and are mutually
+// exclusive.
+func BuildTagFilter(first, any, all string) (TagFilter, error) {
+	// Ensure only one tag filter type is given.
+	if (first != "" && any != "") || (first != "" && all != "") || (any != "" && all != "") {
+		return nil, fmt.Errorf("only one tag filter type may be specified")
+	}
+
+	switch {
+	case first != "":
+		re, err := regexp.Compile(first)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile tag_filter regular expression %q: %w", first, err)
+		}
+		return &TagFilterFirst{re}, nil
+	case any != "":
+		re, err := regexp.Compile(any)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile tag_filter_any regular expression %q: %w", any, err)
+		}
+		return &TagFilterAny{re}, nil
+	case all != "":
+		re, err := regexp.Compile(all)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile tag_filter_all regular expression %q: %w", all, err)
+		}
+		return &TagFilterAll{re}, nil
+	default:
+		// If no filters were provided, return the null filter which just returns
+		// false for all matches. This preserves the "allow_tagged" behavior.
+		return &TagFilterNull{}, nil
+	}
+}
+
+var _ TagFilter = (*TagFilterNull)(nil)
+
+// TagFilterNull always returns false.
+type TagFilterNull struct{}
+
+func (f *TagFilterNull) Matches(tags []string) bool {
+	return false
+}
+
+var _ TagFilter = (*TagFilterFirst)(nil)
+
+// TagFilterFirst filters based on the first item in the list. If the list is
+// empty or if the first item does not match the regex, it returns false.
+type TagFilterFirst struct {
+	re *regexp.Regexp
+}
+
+func (f *TagFilterFirst) Matches(tags []string) bool {
+	if len(tags) < 1 || f.re == nil {
+		return false
+	}
+	return f.re.MatchString(tags[0])
+}
+
+var _ TagFilter = (*TagFilterAny)(nil)
+
+// TagFilterAny filters based on the entire list. If any tag in the list
+// matches, it returns true. If no tags match, it returns false.
+type TagFilterAny struct {
+	re *regexp.Regexp
+}
+
+func (f *TagFilterAny) Matches(tags []string) bool {
+	if f.re == nil {
+		return false
+	}
+	for _, t := range tags {
+		if f.re.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}
+
+var _ TagFilter = (*TagFilterAll)(nil)
+
+// TagFilterAll filters based on the entire list. If all tags in the last match,
+// it returns true. If one more more tags do not match, it returns false.
+type TagFilterAll struct {
+	re *regexp.Regexp
+}
+
+func (f *TagFilterAll) Matches(tags []string) bool {
+	if f.re == nil {
+		return false
+	}
+	for _, t := range tags {
+		if !f.re.MatchString(t) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/gcrcleaner/filter_test.go
+++ b/pkg/gcrcleaner/filter_test.go
@@ -1,0 +1,257 @@
+// Copyright 2021 The GCR Cleaner Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcrcleaner
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestBuildTagFilter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		first, any, all string
+		err             bool
+		exp             reflect.Type
+	}{
+		{
+			name:  "empty",
+			first: "",
+			any:   "",
+			all:   "",
+			exp:   reflect.TypeOf(&TagFilterNull{}),
+		},
+		{
+			name:  "first_any",
+			first: "a",
+			any:   "b",
+			all:   "",
+			err:   true,
+		},
+		{
+			name:  "first_all",
+			first: "a",
+			any:   "",
+			all:   "c",
+			err:   true,
+		},
+		{
+			name:  "any_all",
+			first: "",
+			any:   "b",
+			all:   "c",
+			err:   true,
+		},
+		{
+			name:  "first",
+			first: "a",
+			any:   "",
+			all:   "",
+			exp:   reflect.TypeOf(&TagFilterFirst{}),
+		},
+		{
+			name:  "any",
+			first: "",
+			any:   "a",
+			all:   "",
+			exp:   reflect.TypeOf(&TagFilterAny{}),
+		},
+		{
+			name:  "all",
+			first: "",
+			any:   "",
+			all:   "a",
+			exp:   reflect.TypeOf(&TagFilterAll{}),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := BuildTagFilter(tc.first, tc.any, tc.all)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if got, want := reflect.TypeOf(f), tc.exp; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}
+
+func TestTagFilterFirst_Matches(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		re   *regexp.Regexp
+		tags []string
+		exp  bool
+	}{
+		{
+			name: "empty_re",
+			re:   nil,
+			tags: nil,
+			exp:  false,
+		},
+		{
+			name: "empty_tags",
+			re:   regexp.MustCompile(`.*`),
+			tags: nil,
+			exp:  false,
+		},
+		{
+			name: "matches_first",
+			re:   regexp.MustCompile(`.*`),
+			tags: []string{"tag1", "tag2"},
+			exp:  true,
+		},
+		{
+			name: "doesnt_match_second",
+			re:   regexp.MustCompile(`^tag2$`),
+			tags: []string{"tag1", "tag2"},
+			exp:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := &TagFilterFirst{re: tc.re}
+			if got, want := f.Matches(tc.tags), tc.exp; got != want {
+				t.Errorf("expected %q matches %q to be %t", tc.re, tc.tags, want)
+			}
+		})
+	}
+}
+
+func TestTagFilterAny_Matches(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		re   *regexp.Regexp
+		tags []string
+		exp  bool
+	}{
+		{
+			name: "empty_re",
+			re:   nil,
+			tags: nil,
+			exp:  false,
+		},
+		{
+			name: "empty_tags",
+			re:   regexp.MustCompile(`.*`),
+			tags: nil,
+			exp:  false,
+		},
+		{
+			name: "matches_first",
+			re:   regexp.MustCompile(`^tag1$`),
+			tags: []string{"tag1", "tag2", "tag3"},
+			exp:  true,
+		},
+		{
+			name: "matches_middle",
+			re:   regexp.MustCompile(`^tag2$`),
+			tags: []string{"tag1", "tag2", "tag3"},
+			exp:  true,
+		},
+		{
+			name: "matches_end",
+			re:   regexp.MustCompile(`^tag3$`),
+			tags: []string{"tag1", "tag2", "tag3"},
+			exp:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := &TagFilterAny{re: tc.re}
+			if got, want := f.Matches(tc.tags), tc.exp; got != want {
+				t.Errorf("expected %q matches %q to be %t", tc.re, tc.tags, want)
+			}
+		})
+	}
+}
+
+func TestTagFilterAll_Matches(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		re   *regexp.Regexp
+		tags []string
+		exp  bool
+	}{
+		{
+			name: "empty_re",
+			re:   nil,
+			tags: nil,
+			exp:  false,
+		},
+		{
+			name: "empty_tags",
+			re:   regexp.MustCompile(`.*`),
+			tags: nil,
+			exp:  true,
+		},
+		{
+			name: "matches_one",
+			re:   regexp.MustCompile(`^tag1$`),
+			tags: []string{"tag1"},
+			exp:  true,
+		},
+		{
+			name: "matches_two",
+			re:   regexp.MustCompile(`^tag1|tag2$`),
+			tags: []string{"tag1", "tag2"},
+			exp:  true,
+		},
+		{
+			name: "does_not_match_all",
+			re:   regexp.MustCompile(`^tag1|tag2$`),
+			tags: []string{"tag1", "tag2", "tag3"},
+			exp:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := &TagFilterAll{re: tc.re}
+			if got, want := f.Matches(tc.tags), tc.exp; got != want {
+				t.Errorf("expected %q matches %q to be %t", tc.re, tc.tags, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This introduces new tag filtering options. The existing behavior for tag filtering only applies to the first element in the tag list, which users have expressed as undesirable. This preserves (but deprecates) this original method and introduces two new methods for tag matching: -tag-filter-any and -tag-filter-all. Both accept a regular expression, but "any" matches if one or more tags match the regular expression, but "all" only matches if all tags match the regular expression.

Fixes GH-54
Closes GH-61
Closes GH-53