### PR TITLE
Adjusting the language to be more accurate.

### DIFF
--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -163,7 +163,7 @@ func realMain(ctx context.Context) error {
 			"actually be cleaned!\n\n")
 	}
 
-	fmt.Fprintf(stdout, "Deleting refs since %s on %d repo(s)...\n\n",
+	fmt.Fprintf(stdout, "Deleting refs older than %s on %d repo(s)...\n\n",
 		since.Format(time.RFC3339), len(repos))
 
 	// Do the deletion.


### PR DESCRIPTION
Grace *skips* deleting images *since* the grace period, which means anything *older than* will be deleted.