### PR TITLE
Alternate fix to duplicate SHAs

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -79,6 +79,8 @@ func (c *Cleaner) Clean(repo string, since time.Time, keep int, tagFilter TagFil
 
 	for _, m := range manifests {
 		if c.shouldDelete(m.Info, since, tagFilter) {
+			// Store copy of manifest for thread safety in delete job pool
+			m := m
 			// Keep a certain amount of images
 			if keepCount < keep {
 				keepCount++


### PR DESCRIPTION
# Description 

Fixes the duplicate and incorrect SHA output by placing the manifest to be deleted in an anonymous function's parameter and immediately invoking. IMO this makes the call stack more clear and safer. Any future refactors can access any of the parameters on the manifest variable without worrying about thread safety. That said, __I completely understand this is a nitpick__. This just came about from me debugging why `v0.7.0` was printing the same SHA and sometimes even the wrong SHA occasionally. However, I still wanted to propose the revision to the community. 

# Background

Commit [834f5cbd9](https://github.com/GoogleCloudPlatform/gcrcleaner/commit/834f5cbd90d6cde6b76ef90870e66556c666d982) fixed an issue where duplicate and potentially wrong SHAs were output. The crux of the bug was that the pool functions tried to access the `m` variable that was declared in the for loop. Since this pointer changed what manifest it was pointing at, it wasn't thread safe. The pool functions would just output the digest of the manifest they were on, This usually manifested as duplicates but sometimes as the wrong SHA. 

The fix for this issue was to store the ref variable directly on the call stack. Since the pool functions no longer were using a pointer of a pointer (m.Digest) that changes during iteration, the calls are safe