### PR TITLE
Switch builder to go 1.18 and drop upx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,31 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 ARG SERVICE
 
-RUN apt-get -qq update && apt-get -yqq install upx
-
 ENV GO111MODULE=on \
+  GOPROXY=https://proxy.golang.org,direct \
   CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64
 
 WORKDIR /src
-
 COPY . .
+
 RUN go build \
   -a \
   -trimpath \
-  -ldflags "-s -w -extldflags '-static'" \
-  -tags 'osusergo netgo static_build' \
+  -ldflags "-s -w -extldflags=-static" \
   -o /bin/gcrcleaner \
   ./cmd/${SERVICE}
 
-RUN strip /bin/gcrcleaner
-RUN upx -q -9 /bin/gcrcleaner
-
+RUN strip -s /bin/gcrcleaner
 
 
 


### PR DESCRIPTION
upx breaks multi-platform Docker images across systems like the M1 Mac, and the savings are really not worth the cost of needing to publish separate binaries.