### PR TITLE
Sort by uploaded date when creation date is old

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,3 +1,0 @@
-daysUntilLock: 90
-lockLabel: false
-lockComment: false

--- a/.github/reaction.yml
+++ b/.github/reaction.yml
@@ -1,1 +1,0 @@
-reactionComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,0 @@
-daysUntilStale: 14
-daysUntilClose: 14
-staleLabel: stale
-closeComment: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: 'test'
+
+on:
+  push:
+    branches:
+    - 'main'
+    tags:
+    - '*'
+  pull_request:
+    branches:
+    - 'main'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    - uses: 'actions/setup-go@v3'
+      with:
+        go-version: '1.18'
+
+    - uses: 'actions/cache@v3'
+      with:
+        path: |-
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |-
+          ${{ runner.os }}-go-
+
+    - run: 'make test'

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,12 @@ docker-push:
 		--config ./cloudbuild/cloudbuild.yaml \
 		.
 .PHONY: docker-push
+
+test:
+	@go test \
+		-count=1 \
+		-race \
+		-shuffle=on \
+		-timeout=10m \
+		./...
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -183,8 +183,24 @@ The payload is expected to be JSON with the following fields:
   the duration will not be deleted. If unspecified, the default is no grace
   period (all untagged image refs are deleted).
 
-- `keep` - If an integer is provided, it will always keep that minimum number
-  of images. Note that it will not consider images inside the `grace` duration.
+- `keep` - If an integer is provided, it will always keep that minimum number of
+  images. Note that it will not consider images inside the `grace` duration. GCR
+  Cleaner attempts to keep the most recently created images, but there are some
+  caveats. Some community tooling sets container creation time to a date back in
+  1980, which breaks the default sorting algorithm. As such, GCR Cleaner uses
+  the following sorting algorithm for container images:
+
+    - If either of the containers were created before Docker even existed, it
+      sorts by the date the container was uploaded to the registry.
+
+    - If two containers were created at the same timestamp, it sorts by the date
+      the container was uploaded to the registry.
+
+    - In all other situations, it sorts by the timestamp the container was
+      created.
+
+  This algorithm exists to preserve ordering for containers that are moved
+  between registries.
 
 - `tag_filter_any` - If specified, any image with at **least one tag** that
   matches this given regular expression will be deleted. The image will be


### PR DESCRIPTION
Certain build tools like pack set the container creation time to the very distant past, like before Docker even existed. This breaks GCR Cleaner's sorting algorithm for "keep". This commit introduces fallback sorting for when the creation date before March 20, 2013 or when two creation dates are equal. In those situations, GCR Cleaner uses the Uploaded date for sorting. In all other cases, it uses the Creation timestamp.

- References: https://github.com/GoogleCloudPlatform/gcr-cleaner/issues/89
- References: https://github.com/GoogleCloudPlatform/gcr-cleaner/pull/88