### PR TITLE
Remove deprecated fields tag_filter, allow_tagged, and repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,6 @@ The payload is expected to be JSON with the following fields:
     and create a dedicated service account that has granular permissions on a
     subset of repositories.
 
-- `tag_filter` (_Deprecated_) - This option is deprecated and only exists to
-  maintain backwards compatibility with some existing broken behavior. You
-  should not use it. If specified, any image where **the first tag** matches
-  this given regular expression will be deleted. The image will not be deleted
-  if other tags match the regular expression. The regular expressions are parsed
-  according to the [Go regexp package][go-re].
-
-- `allow_tagged` (_Deprecated_) - This option is deprecated and has no effect.
-  By default, GCR Cleaner will not delete tagged images. To delete tagged
-  images, specify `tag_filter_any` or `tag_filter_all`. Specifying either of
-  these will enable deletion by tag.
-
 
 ## Permissions
 

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -51,11 +51,6 @@ var (
 	tagFilterAll = flag.String("tag-filter-all", "", "Delete images where all tags match this regular expression")
 	keepPtr      = flag.Int("keep", 0, "Minimum to keep")
 	dryRunPtr    = flag.Bool("dry-run", false, "Do a noop on delete api call")
-
-	// tagFilterPtr and allow-tagged are deprecated
-	// TODO(sethvargo): remove before 1.0.0
-	allowTaggedPtr    = flag.Bool("allow-tagged", false, "DEPRECATED: Delete tagged images")
-	tagFilterFirstPtr = flag.String("tag-filter", "", "DEPRECATED: Tags pattern to clean")
 )
 
 func main() {
@@ -115,14 +110,7 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 	}
 	sort.Strings(repos)
 
-	if *allowTaggedPtr {
-		fmt.Fprintf(stderr, "DEPRECATION: -allow-tagged is deprecated, specifying any tags will enable deleting of tagged images\n")
-	}
-	if *tagFilterFirstPtr != "" {
-		fmt.Fprintf(stderr, "DEPRECATION: -tag-filter is deprecated, use -tag-filter-any or -tag-filter-all instead\n")
-	}
-
-	tagFilter, err := gcrcleaner.BuildTagFilter(*tagFilterFirstPtr, *tagFilterAny, *tagFilterAll)
+	tagFilter, err := gcrcleaner.BuildTagFilter(*tagFilterAny, *tagFilterAll)
 	if err != nil {
 		return fmt.Errorf("failed to parse tag filter: %w", err)
 	}

--- a/pkg/gcrcleaner/filter_test.go
+++ b/pkg/gcrcleaner/filter_test.go
@@ -24,59 +24,34 @@ func TestBuildTagFilter(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name            string
-		first, any, all string
-		err             bool
-		exp             reflect.Type
+		name     string
+		any, all string
+		err      bool
+		exp      reflect.Type
 	}{
 		{
-			name:  "empty",
-			first: "",
-			any:   "",
-			all:   "",
-			exp:   reflect.TypeOf(&TagFilterNull{}),
+			name: "empty",
+			any:  "",
+			all:  "",
+			exp:  reflect.TypeOf(&TagFilterNull{}),
 		},
 		{
-			name:  "first_any",
-			first: "a",
-			any:   "b",
-			all:   "",
-			err:   true,
+			name: "any_all",
+			any:  "b",
+			all:  "c",
+			err:  true,
 		},
 		{
-			name:  "first_all",
-			first: "a",
-			any:   "",
-			all:   "c",
-			err:   true,
+			name: "any",
+			any:  "a",
+			all:  "",
+			exp:  reflect.TypeOf(&TagFilterAny{}),
 		},
 		{
-			name:  "any_all",
-			first: "",
-			any:   "b",
-			all:   "c",
-			err:   true,
-		},
-		{
-			name:  "first",
-			first: "a",
-			any:   "",
-			all:   "",
-			exp:   reflect.TypeOf(&TagFilterFirst{}),
-		},
-		{
-			name:  "any",
-			first: "",
-			any:   "a",
-			all:   "",
-			exp:   reflect.TypeOf(&TagFilterAny{}),
-		},
-		{
-			name:  "all",
-			first: "",
-			any:   "",
-			all:   "a",
-			exp:   reflect.TypeOf(&TagFilterAll{}),
+			name: "all",
+			any:  "",
+			all:  "a",
+			exp:  reflect.TypeOf(&TagFilterAll{}),
 		},
 	}
 
@@ -86,61 +61,12 @@ func TestBuildTagFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := BuildTagFilter(tc.first, tc.any, tc.all)
+			f, err := BuildTagFilter(tc.any, tc.all)
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
 			if got, want := reflect.TypeOf(f), tc.exp; got != want {
 				t.Errorf("expected %v to be %v", got, want)
-			}
-		})
-	}
-}
-
-func TestTagFilterFirst_Matches(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		re   *regexp.Regexp
-		tags []string
-		exp  bool
-	}{
-		{
-			name: "empty_re",
-			re:   nil,
-			tags: nil,
-			exp:  false,
-		},
-		{
-			name: "empty_tags",
-			re:   regexp.MustCompile(`.*`),
-			tags: nil,
-			exp:  false,
-		},
-		{
-			name: "matches_first",
-			re:   regexp.MustCompile(`.*`),
-			tags: []string{"tag1", "tag2"},
-			exp:  true,
-		},
-		{
-			name: "doesnt_match_second",
-			re:   regexp.MustCompile(`^tag2$`),
-			tags: []string{"tag1", "tag2"},
-			exp:  false,
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			f := &TagFilterFirst{re: tc.re}
-			if got, want := f.Matches(tc.tags), tc.exp; got != want {
-				t.Errorf("expected %q matches %q to be %t", tc.re, tc.tags, want)
 			}
 		})
 	}


### PR DESCRIPTION
These fields have been deprecated for a long time. This removes them in preparation for a 1.0 release.