### PR TITLE
Adding volume for gcloud configuration on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For one-off tasks, you can also run GCR Cleaner locally:
 
 ```text
 docker run -it us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli
+docker run -v $HOME/.config/gcloud:/.config/gcloud -it us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli
 ```
 
 **This is not an official Google product.**


### PR DESCRIPTION
It's written nowhere that, we need to add a volume to get the gcloud configuration and so, connecting gcr-cleaner to our docker registry. While modifying this, it could help peoples who wouldn't have the reflex to add the volume

Signed-off-by: Yanis Corselle <102953852+yanis-incepto@users.noreply.github.com>