### PR TITLE
Do not error if digest cannot be deleted due to dangling parent image

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -190,9 +190,15 @@ func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep 
 
 				if !dryRun {
 					if err := c.deleteOne(ctx, ref); err != nil {
-						errsLock.Lock()
-						errs = append(errs, fmt.Errorf("failed to delete digest %s: %w", ref, err))
-						errsLock.Unlock()
+						if (strings.Contains(err.Error(), "GOOGLE_MANIFEST_DANGLING_PARENT_IMAGE")) {
+							c.logger.Debug("could not delete digest due to dangling parent image",
+								"repo", repo,
+								"digest", m.Digest)
+						} else {
+							errsLock.Lock()
+							errs = append(errs, fmt.Errorf("failed to delete digest %s: %w", ref, err))
+							errsLock.Unlock()
+						}
 					}
 				}
 


### PR DESCRIPTION
This would fix the problem described in #118, except I didn't implement any kind of flag - I'm not a go developer at all and I barely managed to get this to build locally and test it - mostly opening this to kickstart a proper fix and maybe it can help someone else.

I tested it for our use case, and it works as expected, but hopefully someone with more experience can test it properly and make it better and/or put it behind a flag. It will also still mark the digests as deleted even though they weren't - not really ideal, but better than an error for us.