### PR TITLE
Add --tag-filter-exclude flag to exclude images, abstract decision logic to interface

### DIFF
--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -45,15 +45,16 @@ var (
 var (
 	reposMap = make(map[string]struct{}, 4)
 
-	tokenPtr       = flag.String("token", os.Getenv("GCRCLEANER_TOKEN"), "Authentication token")
-	recursivePtr   = flag.Bool("recursive", false, "Clean all sub-repositories under the -repo root")
-	gracePtr       = flag.Duration("grace", 0, "Grace period")
-	tagFilterAny   = flag.String("tag-filter-any", "", "Delete images where any tag matches this regular expression")
-	tagFilterAll   = flag.String("tag-filter-all", "", "Delete images where all tags match this regular expression")
-	keepPtr        = flag.Int64("keep", 0, "Minimum to keep")
-	dryRunPtr      = flag.Bool("dry-run", false, "Do a noop on delete api call")
-	concurrencyPtr = flag.Int64("concurrency", 20, "Concurrent requests (defaults to number of CPUs)")
-	versionPtr     = flag.Bool("version", false, "Print version information and exit")
+	tokenPtr            = flag.String("token", os.Getenv("GCRCLEANER_TOKEN"), "Authentication token")
+	recursivePtr        = flag.Bool("recursive", false, "Clean all sub-repositories under the -repo root")
+	gracePtr            = flag.Duration("grace", 0, "Grace period")
+	tagFilterAny        = flag.String("tag-filter-any", "", "Delete images where any tag matches this regular expression")
+	tagFilterAll        = flag.String("tag-filter-all", "", "Delete images where all tags match this regular expression")
+	tagFilterExcludePtr = flag.Bool("tag-filter-exclude", false, "Boolean to exclude images instead of delete. Defaults to false")
+	keepPtr             = flag.Int64("keep", 0, "Minimum to keep")
+	dryRunPtr           = flag.Bool("dry-run", false, "Do a noop on delete api call")
+	concurrencyPtr      = flag.Int64("concurrency", 20, "Concurrent requests (defaults to number of CPUs)")
+	versionPtr          = flag.Bool("version", false, "Print version information and exit")
 )
 
 func main() {
@@ -175,7 +176,7 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 	var errs []error
 	for i, repo := range repos {
 		fmt.Fprintf(stdout, "%s\n", repo)
-		deleted, err := cleaner.Clean(ctx, repo, since, *keepPtr, tagFilter, *dryRunPtr)
+		deleted, err := cleaner.Clean(ctx, repo, since, *keepPtr, tagFilter, *tagFilterExcludePtr, *dryRunPtr)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -147,7 +147,7 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 		TagFilterExclude: *tagFilterExcludePtr,
 		Logger:           logger,
 	}
-	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, *concurrencyPtr, &defaultDecider)
+	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, *concurrencyPtr)
 	if err != nil {
 		return fmt.Errorf("failed to create cleaner: %w", err)
 	}
@@ -181,7 +181,7 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 	var errs []error
 	for i, repo := range repos {
 		fmt.Fprintf(stdout, "%s\n", repo)
-		deleted, err := cleaner.Clean(ctx, repo, since, *keepPtr, tagFilter, *tagFilterExcludePtr, *dryRunPtr)
+		deleted, err := cleaner.Clean(ctx, repo, since, *keepPtr, &defaultDecider, *dryRunPtr)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -133,11 +133,6 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 		gcrgoogle.Keychain,
 	)
 
-	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, *concurrencyPtr)
-	if err != nil {
-		return fmt.Errorf("failed to create cleaner: %w", err)
-	}
-
 	// Convert duration to a negative value, since we're about to "add" it to the
 	// since time.
 	sub := time.Duration(*gracePtr)
@@ -146,6 +141,16 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 	}
 	since := time.Now().UTC().Add(sub)
 
+	defaultDecider := gcrcleaner.DefaultDecider{
+		Since:            since,
+		TagFilter:        tagFilter,
+		TagFilterExclude: *tagFilterExcludePtr,
+		Logger:           logger,
+	}
+	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, *concurrencyPtr, &defaultDecider)
+	if err != nil {
+		return fmt.Errorf("failed to create cleaner: %w", err)
+	}
 	// Gather the repositories.
 	if *recursivePtr {
 		logger.Debug("gathering child repositories recursively")

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -140,13 +140,6 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 		sub = sub * -1
 	}
 	since := time.Now().UTC().Add(sub)
-
-	defaultDecider := gcrcleaner.DefaultDecider{
-		Since:            since,
-		TagFilter:        tagFilter,
-		TagFilterExclude: *tagFilterExcludePtr,
-		Logger:           logger,
-	}
 	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, *concurrencyPtr)
 	if err != nil {
 		return fmt.Errorf("failed to create cleaner: %w", err)
@@ -177,11 +170,17 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 	fmt.Fprintf(stdout, "Deleting refs older than %s on %d repo(s)...\n\n",
 		since.Format(time.RFC3339), len(repos))
 
+	defaultDecider := gcrcleaner.DefaultDecider{
+		Since:            since,
+		TagFilter:        tagFilter,
+		TagFilterExclude: *tagFilterExcludePtr,
+		Logger:           logger,
+	}
 	// Do the deletion.
 	var errs []error
 	for i, repo := range repos {
 		fmt.Fprintf(stdout, "%s\n", repo)
-		deleted, err := cleaner.Clean(ctx, repo, since, *keepPtr, &defaultDecider, *dryRunPtr)
+		deleted, err := cleaner.Clean(ctx, repo, *keepPtr, &defaultDecider, *dryRunPtr)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/gcr-cleaner-server/main.go
+++ b/cmd/gcr-cleaner-server/main.go
@@ -83,12 +83,6 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 		gcrgoogle.Keychain,
 	)
 
-	defaultDecider := gcrcleaner.DefaultDecider{
-		Since:            since,
-		TagFilter:        tagFilter,
-		TagFilterExclude: *tagFilterExcludePtr,
-		Logger:           logger,
-	}
 	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, concurrency)
 	if err != nil {
 		return fmt.Errorf("failed to create cleaner: %w", err)

--- a/cmd/gcr-cleaner-server/main.go
+++ b/cmd/gcr-cleaner-server/main.go
@@ -83,6 +83,12 @@ func realMain(ctx context.Context, logger *gcrcleaner.Logger) error {
 		gcrgoogle.Keychain,
 	)
 
+	defaultDecider := gcrcleaner.DefaultDecider{
+		Since:            since,
+		TagFilter:        tagFilter,
+		TagFilterExclude: *tagFilterExcludePtr,
+		Logger:           logger,
+	}
 	cleaner, err := gcrcleaner.NewCleaner(keychain, logger, concurrency)
 	if err != nil {
 		return fmt.Errorf("failed to create cleaner: %w", err)

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -63,7 +63,7 @@ func NewCleaner(keychain gcrauthn.Keychain, logger *Logger, concurrency int64) (
 
 // Clean deletes old images from GCR based on decider and older than "since"
 // and higher than the "keep" amount.
-func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep int64, d Decider, dryRun bool) ([]string, error) {
+func (c *Cleaner) Clean(ctx context.Context, repo string, keep int64, d Decider, dryRun bool) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -63,7 +63,7 @@ func NewCleaner(keychain gcrauthn.Keychain, logger *Logger, concurrency int64) (
 
 // Clean deletes old images from GCR that are (un)tagged and older than "since"
 // and higher than the "keep" amount.
-func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep int64, tagFilter TagFilter, dryRun bool) ([]string, error) {
+func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep int64, tagFilter TagFilter, tagFilterExclude bool, dryRun bool) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
@@ -136,7 +136,7 @@ func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep 
 			"uploaded", m.Info.Uploaded.Format(time.RFC3339))
 
 		// Do nothing if this is not a candidate.
-		if !c.shouldDelete(m, since, tagFilter) {
+		if !c.shouldDelete(m, since, tagFilter, tagFilterExclude) {
 			c.logger.Debug("skipping deletion because of filters",
 				"repo", repo,
 				"digest", m.Digest,
@@ -330,7 +330,7 @@ func (c *Cleaner) deleteOne(ctx context.Context, ref gcrname.Reference) error {
 
 // shouldDelete returns true if the manifest was created before the given
 // timestamp and either has no tags or has tags that match the given filter.
-func (c *Cleaner) shouldDelete(m *manifest, since time.Time, tagFilter TagFilter) bool {
+func (c *Cleaner) shouldDelete(m *manifest, since time.Time, tagFilter TagFilter, tagFilterExclude bool) bool {
 	// Immediately exclude images that have been uploaded after the given time.
 	if uploaded := m.Info.Uploaded.UTC(); uploaded.After(since) {
 		c.logger.Debug("should not delete",
@@ -356,7 +356,16 @@ func (c *Cleaner) shouldDelete(m *manifest, since time.Time, tagFilter TagFilter
 	// If tagged images are allowed and the given filter matches the list of tags,
 	// this is a deletion candidate. The default tag filter is to reject all
 	// strings.
-	if tagFilter.Matches(m.Info.Tags) {
+	if tagFilter.Matches(m.Info.Tags) && !tagFilterExclude {
+		c.logger.Debug("should delete",
+			"repo", m.Repo,
+			"digest", m.Digest,
+			"reason", "matches tag filter",
+			"tags", m.Info.Tags,
+			"tag_filter", tagFilter.Name())
+		return true
+	}
+	if !tagFilter.Matches(m.Info.Tags) && tagFilterExclude {
 		c.logger.Debug("should delete",
 			"repo", m.Repo,
 			"digest", m.Digest,

--- a/pkg/gcrcleaner/decider.go
+++ b/pkg/gcrcleaner/decider.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The GCR Cleaner Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcrcleaner cleans up stale images from a container registry.
+package gcrcleaner
+
+import "time"
+
+type Decider interface {
+	ShouldDelete(*Manifest) (bool, error)
+}
+
+type DefaultDecider struct {
+	Since            time.Time
+	TagFilter        TagFilter
+	TagFilterExclude bool
+	Logger           *Logger
+}
+
+func (d *DefaultDecider) ShouldDelete(m *Manifest) (bool, error) {
+	// Immediately exclude images that have been uploaded after the given time.
+	if uploaded := m.Info.Uploaded.UTC(); uploaded.After(d.Since) {
+		d.Logger.Debug("should not delete",
+			"repo", m.Repo,
+			"digest", m.Digest,
+			"reason", "too new",
+			"since", d.Since.Format(time.RFC3339),
+			"created", m.Info.Created.Format(time.RFC3339),
+			"uploaded", uploaded.Format(time.RFC3339),
+			"delta", uploaded.Sub(d.Since).String())
+		return false, nil
+	}
+
+	// If there are no tags, it should be deleted.
+	if len(m.Info.Tags) == 0 {
+		d.Logger.Debug("should delete",
+			"repo", m.Repo,
+			"digest", m.Digest,
+			"reason", "no tags")
+		return true, nil
+	}
+
+	// If tagged images are allowed and the given filter matches the list of tags,
+	// this is a deletion candidate. The default tag filter is to reject all
+	// strings.
+	if d.TagFilter.Matches(m.Info.Tags) && !d.TagFilterExclude {
+		d.Logger.Debug("should delete",
+			"repo", m.Repo,
+			"digest", m.Digest,
+			"reason", "matches tag filter",
+			"tags", m.Info.Tags,
+			"tag_filter", d.TagFilter.Name())
+		return true, nil
+	}
+	if !d.TagFilter.Matches(m.Info.Tags) && d.TagFilterExclude {
+		d.Logger.Debug("should delete",
+			"repo", m.Repo,
+			"digest", m.Digest,
+			"reason", "matches tag filter",
+			"tags", m.Info.Tags,
+			"tag_filter", d.TagFilter.Name())
+		return true, nil
+	}
+
+	// If we got this far, it'ts not a viable deletion candidate.
+	d.Logger.Debug("should not delete",
+		"repo", m.Repo,
+		"digest", m.Digest,
+		"reason", "no filter matches")
+	return false, nil
+}

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -182,10 +182,16 @@ func (s *Server) clean(ctx context.Context, r io.ReadCloser) (map[string][]strin
 
 	// Do the deletion.
 	deleted := make(map[string][]string, len(repos))
+	defaultDecider := DefaultDecider{
+		Since:            since,
+		TagFilter:        tagFilter,
+		TagFilterExclude: p.TagFilterExclude,
+		Logger:           s.logger,
+	}
 	for _, repo := range repos {
 		s.logger.Info("deleting refs for repo", "repo", repo)
 
-		childrenDeleted, err := s.cleaner.Clean(ctx, repo, since, p.Keep, tagFilter, p.TagFilterExclude, p.DryRun)
+		childrenDeleted, err := s.cleaner.Clean(ctx, repo, since, p.Keep, &defaultDecider, p.DryRun)
 		if err != nil {
 			return nil, http.StatusBadRequest, fmt.Errorf("failed to clean repo %q: %w", repo, err)
 		}

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -185,7 +185,7 @@ func (s *Server) clean(ctx context.Context, r io.ReadCloser) (map[string][]strin
 	for _, repo := range repos {
 		s.logger.Info("deleting refs for repo", "repo", repo)
 
-		childrenDeleted, err := s.cleaner.Clean(ctx, repo, since, p.Keep, tagFilter, p.DryRun)
+		childrenDeleted, err := s.cleaner.Clean(ctx, repo, since, p.Keep, tagFilter, p.TagFilterExclude, p.DryRun)
 		if err != nil {
 			return nil, http.StatusBadRequest, fmt.Errorf("failed to clean repo %q: %w", repo, err)
 		}
@@ -240,6 +240,11 @@ type Payload struct {
 	// The image will not be delete if it has other tags that do not match the
 	// given regular expression.
 	TagFilterAll string `json:"tag_filter_all"`
+
+	// TagFilterExclude instructs the server to exclude tags that were matched from deletion to
+	// be deleted
+	// If true, image will be deleted if the tag filter does NOT match
+	TagFilterExclude bool `json:"tag_filter_exclude"`
 
 	// DryRun instructs the server to not perform actual cleaning. The response
 	// will include repositories that would have been deleted.

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -191,7 +191,7 @@ func (s *Server) clean(ctx context.Context, r io.ReadCloser) (map[string][]strin
 	for _, repo := range repos {
 		s.logger.Info("deleting refs for repo", "repo", repo)
 
-		childrenDeleted, err := s.cleaner.Clean(ctx, repo, since, p.Keep, &defaultDecider, p.DryRun)
+		childrenDeleted, err := s.cleaner.Clean(ctx, repo, p.Keep, &defaultDecider, p.DryRun)
 		if err != nil {
 			return nil, http.StatusBadRequest, fmt.Errorf("failed to clean repo %q: %w", repo, err)
 		}


### PR DESCRIPTION
### Summary

* Fixes #65
* Move decision logic to separate interface to allow custom logic to be applied when using gcr-cleaner as a go package.

To delete everything more than 720hours old, except images with tag `special-tag`
```
gcr-cleaner-cli -dry-run -repo gcr.io/foo/bar -grace 720h -tag-filter-exclude -tag-filter-any 'special-tag'
```