### PR TITLE
Fix cronjob indentation

### DIFF
--- a/docs/deploy-gke.md
+++ b/docs/deploy-gke.md
@@ -90,10 +90,10 @@ spec:
             - -grace=720h # 30 days
             - -recursive
             - -tag-filter-any=.*
-            restartPolicy: Never
-            serviceAccountName: gcr-cleaner
-            nodeSelector:
-              iam.gke.io/gke-metadata-server-enabled: "true"
+          restartPolicy: Never
+          serviceAccountName: gcr-cleaner
+          nodeSelector:
+            iam.gke.io/gke-metadata-server-enabled: "true"
 ```
 
 


### PR DESCRIPTION
These fields are properties of `spec` and not `containers[*]`

Note that while the root readme suggests that this repository is mostly closed, the [contributing guidelines](https://github.com/GoogleCloudPlatform/gcr-cleaner/blob/a315d2a33985a73663523432412cd2ce7c03840b/CONTRIBUTING.md) still say that this repository welcomes contributions.

As this isn't a feature request and isn't a change to the implementation, I think it's reasonable to merge this fix so that people who try to use this doc will not run into the issue fixed here...